### PR TITLE
refactor: move species map to dedicated module

### DIFF
--- a/src/PlantGrowerGame.js
+++ b/src/PlantGrowerGame.js
@@ -1,0 +1,29 @@
+import { SPECIES } from './data/species.js';
+
+/**
+ * A minimal plant growing game that utilises predefined plant species.
+ */
+export class PlantGrowerGame {
+  constructor() {
+    /** @type {Record<string, number>} */
+    this.inventory = {};
+  }
+
+  /**
+   * Plant a seed of the given species, reducing currency based on seed cost.
+   *
+   * @param {string} speciesName - Key of the species to plant.
+   * @returns {Species} configuration for the planted species.
+   * @throws {Error} if the species name is invalid.
+   */
+  plant(speciesName) {
+    const species = SPECIES[speciesName];
+    if (!species) {
+      throw new Error(`Unknown species: ${speciesName}`);
+    }
+    this.inventory[speciesName] = (this.inventory[speciesName] || 0) + 1;
+    return species;
+  }
+}
+
+export default PlantGrowerGame;

--- a/src/data/species.js
+++ b/src/data/species.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {Object} Species
+ * @property {number} seedCost Cost to purchase one seed.
+ * @property {number} growthDays Number of in-game days required to mature.
+ * @property {number} yield Number of produce yielded at harvest.
+ */
+
+/** @type {Record<string, Species>} */
+export const SPECIES = {
+  /**
+   * Sunflower is a tall annual plant known for its large head that tracks the sun.
+   */
+  sunflower: {
+    seedCost: 5,
+    growthDays: 10,
+    yield: 3,
+  },
+  /**
+   * Tulip is a spring-blooming perennial that produces bright, cup-shaped flowers.
+   */
+  tulip: {
+    seedCost: 3,
+    growthDays: 7,
+    yield: 2,
+  },
+};
+
+export default SPECIES;


### PR DESCRIPTION
## Summary
- move plant species map to new `src/data/species.js` module and document its properties
- update `PlantGrowerGame` to import and use the exported `SPECIES` map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b65864cc832d83b10116257870fd