### PR TITLE
feat: add season and weather system

### DIFF
--- a/__tests__/game.test.js
+++ b/__tests__/game.test.js
@@ -7,6 +7,15 @@ describe('PlantGame actions', () => {
     const game = new PlantGame();
     game.act();
     expect(game.state.day).toBe(1);
+    expect(game.state.season).toBe('spring');
+    expect(game.state.weather).toBe('sunny');
+  });
+
+  test('consecutive acts toggle weather', () => {
+    const game = new PlantGame();
+    game.act();
+    game.act();
+    expect(game.state.weather).toBe('rainy');
   });
 
   test('start triggers periodic TICK actions', () => {

--- a/__tests__/plantReducer.test.js
+++ b/__tests__/plantReducer.test.js
@@ -6,13 +6,29 @@ describe('plantReducer', () => {
     expect(state.day).toBe(1);
     expect(state.height).toBe(1);
     expect(state.water).toBe(2);
+    expect(state.season).toBe('spring');
+    expect(state.weather).toBe('sunny');
   });
 
   test('WATER adds water but does not change day or height', () => {
-    const preState = { ...initialState, day: 5, height: 3, water: 1 };
+    const preState = { ...initialState, day: 5, height: 3, water: 1, season: 'spring', weather: 'sunny' };
     const state = plantReducer(preState, { type: WATER });
     expect(state.water).toBe(3);
     expect(state.day).toBe(5);
     expect(state.height).toBe(3);
+    expect(state.season).toBe('spring');
+    expect(state.weather).toBe('sunny');
+  });
+
+  test('season transitions and weather affects water', () => {
+    let state = initialState;
+    for (let i = 0; i < 30; i++) {
+      state = plantReducer(state, { type: TICK });
+    }
+    expect(state.day).toBe(30);
+    expect(state.season).toBe('summer');
+    expect(state.weather).toBe('rainy');
+    expect(state.height).toBe(31);
+    expect(state.water).toBe(3);
   });
 });

--- a/src/plantReducer.js
+++ b/src/plantReducer.js
@@ -1,21 +1,33 @@
 const TICK = 'TICK';
 const WATER = 'WATER';
 
+const SEASONS = ['spring', 'summer', 'autumn', 'winter'];
+
 const initialState = {
   day: 0,
   water: 3,
   height: 0,
+  season: 'spring',
+  weather: 'sunny',
 };
 
 function plantReducer(state = initialState, action) {
   switch (action.type) {
-    case TICK:
+    case TICK: {
+      const day = state.day + 1;
+      const season = SEASONS[Math.floor(day / 30) % SEASONS.length];
+      const weather = day % 2 === 0 ? 'rainy' : 'sunny';
+      const growth = season === 'summer' ? 2 : season === 'winter' ? 0 : 1;
+      const waterDelta = weather === 'rainy' ? 1 : -1;
       return {
         ...state,
-        day: state.day + 1,
-        water: Math.max(0, state.water - 1),
-        height: state.height + 1,
+        day,
+        season,
+        weather,
+        water: Math.max(0, state.water + waterDelta),
+        height: state.height + growth,
       };
+    }
     case WATER:
       return {
         ...state,
@@ -29,6 +41,7 @@ function plantReducer(state = initialState, action) {
 module.exports = {
   TICK,
   WATER,
+  SEASONS,
   initialState,
   plantReducer,
 };


### PR DESCRIPTION
## Summary
- add season and weather cycles that impact growth and water
- cover seasonal transitions and weather toggling in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b7f8cd88832db7856c81990cded0